### PR TITLE
Matches heading up to device orientation

### DIFF
--- a/TAKTracker.xcodeproj/project.pbxproj
+++ b/TAKTracker.xcodeproj/project.pbxproj
@@ -620,8 +620,7 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -657,8 +656,7 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/TAKTracker/LocationManager.swift
+++ b/TAKTracker/LocationManager.swift
@@ -18,6 +18,7 @@ class LocationManager: NSObject,CLLocationManagerDelegate, ObservableObject {
     var shouldUpdateCoordinateRegion = true
 
     private let manager = CLLocationManager()
+
     override init() {
         super.init()
         manager.delegate = self
@@ -64,5 +65,30 @@ class LocationManager: NSObject,CLLocationManagerDelegate, ObservableObject {
         
         guard let heading = manager.heading else { TAKLogger.debug("No heading!"); return }
         lastHeading = heading
+    }
+    
+    func deviceUpdatedOrientation(orientation: UIDeviceOrientation) {
+        let START_UP = 0
+        let PORTRAIT = 1
+        let LANDSCAPE = 3
+        
+        TAKLogger.debug("[LocationManager]: Device Rotated \(orientation.rawValue)")
+        
+        switch(orientation.rawValue) {
+        case START_UP, PORTRAIT:
+            manager.headingOrientation = .portrait
+        case LANDSCAPE:
+            // It is worth noting that we only allow
+            // Portrait and Landscape Right as the orientations
+            // However the *heading* orientation appears to
+            // need to be told the opposite of the device orientation
+            manager.headingOrientation = .landscapeLeft
+        default:
+            // Ignore since it's an unsupported orientation
+            TAKLogger.debug("[LocationManager]: Received an unsupported device rotation. Ignoring.")
+        }
+        
+        // Let the manager know something is up
+        manager.startUpdatingHeading()
     }
 }


### PR DESCRIPTION
As noted in Issue #16 when the device was rotated the heading / compass was off by 90 degrees. This PR locks the orientation to one of two supported modes (Portrait, or "Landscape Right" as it would be in a holder) and then updates the heading orientation to match....


...sort of. As noted in the code "Landscape Right" _orientation_ requires the `headingOrientation` to be set to `LandscapeLeft`. This was thoroughly tested to ensure that's what we needed to do. We'll set up a test case and be filing a bug report with Apple.