### PR TITLE
Adds Emergency Beacon Alerts

### DIFF
--- a/TAKTracker.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TAKTracker.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
       "location" : "https://github.com/flighttactics/SwiftTAK",
       "state" : {
         "branch" : "main",
-        "revision" : "7e2b387a15ab826ec968d0a3919a5a4f5925f713"
+        "revision" : "8b6870e69f1b84b5071c1c027a3ea22565e11c94"
       }
     },
     {

--- a/TAKTracker/Data Models/SettingsStore.swift
+++ b/TAKTracker/Data Models/SettingsStore.swift
@@ -199,6 +199,18 @@ class SettingsStore: ObservableObject {
         }
     }
     
+    @Published var isAlertActivated: Bool {
+        didSet {
+            UserDefaults.standard.set(isAlertActivated, forKey: "isAlertActivated")
+        }
+    }
+    
+    @Published var activeAlertType: String {
+        didSet {
+            UserDefaults.standard.set(activeAlertType, forKey: "activeAlertType")
+        }
+    }
+    
     private init() {
         let defaultSign = "TRACKER-\(Int.random(in: 1..<40))"
         self.callSign = (UserDefaults.standard.object(forKey: "callSign") == nil ? defaultSign : UserDefaults.standard.object(forKey: "callSign") as! String)
@@ -249,5 +261,8 @@ class SettingsStore: ObservableObject {
         
         self.mapTypeDisplay = (UserDefaults.standard.object(forKey: "mapTypeDisplay") == nil ? MKMapType.standard.rawValue : UserDefaults.standard.object(forKey: "mapTypeDisplay") as! UInt)
 
+        self.isAlertActivated = (UserDefaults.standard.object(forKey: "isAlertActivated") == nil ? false : UserDefaults.standard.object(forKey: "isAlertActivated") as! Bool)
+        
+        self.activeAlertType = (UserDefaults.standard.object(forKey: "activeAlertType") == nil ? "" : UserDefaults.standard.object(forKey: "activeAlertType") as! String)
     }
 }

--- a/TAKTracker/Screens/AlertView.swift
+++ b/TAKTracker/Screens/AlertView.swift
@@ -9,7 +9,96 @@ import Foundation
 import SwiftUI
 
 struct AlertView: View {
+    @Environment(\.dismiss) var dismiss
+    @State var alertActivated: Bool = false
+    @State var alertConfirmed: Bool = false
+    @State var alertType: String = "Cancel"
+    
     var body: some View {
-        Text("Alert")
+        List {
+            Text("Emergency Beacon")
+                .frame(maxWidth: .infinity, alignment: .center)
+                .font(.system(size: 18, weight: .heavy))
+                .listRowSeparator(.hidden)
+            Text("Turn on both switches to initiate emergency beacon")
+                .frame(maxWidth: .infinity, alignment: .center)
+                .listRowSeparator(.hidden)
+            Group {
+                VStack {
+                    HStack {
+                        Text("Activate Alert")
+                            .font(.system(size: 18, weight: .medium))
+                            .foregroundColor(.secondary)
+                        Spacer()
+                    }
+                    Picker(selection: $alertActivated, label: Text("Activate Alert"), content: {
+                        Text("Off").tag(false)
+                        Text("On").tag(true)
+                    })
+                    .pickerStyle(.segmented)
+                    .background(alertActivated ? Color.red : Color.white)
+                }
+            }
+            .listRowSeparator(.hidden)
+            
+            Group {
+                VStack {
+                    HStack {
+                        Text("Confirm Alert")
+                            .font(.system(size: 18, weight: .medium))
+                            .foregroundColor(.secondary)
+                        Spacer()
+                    }
+                    Picker(selection: $alertConfirmed, label: Text("Confirm Alert"), content: {
+                        Text("Off").tag(false)
+                        Text("On").tag(true)
+                    })
+                    .pickerStyle(.segmented)
+                    .background(alertConfirmed ? Color.red : Color.white)
+                }
+            }
+            .listRowSeparator(.hidden)
+            
+            Group {
+                VStack {
+                    HStack {
+                        Text("Alert Type")
+                            .font(.system(size: 18, weight: .medium))
+                            .foregroundColor(.secondary)
+                        Spacer()
+                    }
+                    Picker(selection: $alertType, label: Text("Alert Type"), content: {
+                        Text("911 Alert").tag("911 Alert")
+                        Text("In Contact").tag("In Contact")
+                        Text("Cancel Alert").tag("Cancel Alert")
+                    })
+                    .pickerStyle(.menu)
+                }
+            }
+            .listRowSeparator(.hidden)
+            
+            HStack {
+                Spacer()
+                Button("Cancel", role: .destructive) {
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                
+                Button("OK", role: .none) {
+                    if(alertType == "Cancel Alert") {
+                        SettingsStore.global.activeAlertType = alertType
+                        SettingsStore.global.isAlertActivated = false
+                        TAKLogger.debug("Alert Cancelled")
+                    } else {
+                        SettingsStore.global.activeAlertType = alertType
+                        SettingsStore.global.isAlertActivated = true
+                        TAKLogger.debug("Alert Activated!")
+                    }
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!(alertActivated && alertConfirmed))
+            }
+        }
     }
 }

--- a/TAKTracker/Screens/MainScreen.swift
+++ b/TAKTracker/Screens/MainScreen.swift
@@ -241,7 +241,8 @@ struct MainScreen: View {
                             }
                             .imageScale(.large)
                             .foregroundColor(settingsStore.isAlertActivated ? .red : .white)
-                            .popover(isPresented: $isAlertPresented) { AlertView()
+                            .popover(isPresented: $isAlertPresented) { AlertView(takManager: takManager,
+                                          location: manager)
                             }
                         Spacer()
                         NavigationLink(destination: ChatView(chatMessage: ChatMessage())) {

--- a/TAKTracker/Screens/MainScreen.swift
+++ b/TAKTracker/Screens/MainScreen.swift
@@ -211,6 +211,7 @@ struct MainScreen: View {
     
     @State var displayUIState = DisplayUIState()
     @State var tracking:MapUserTrackingMode = .none
+    @State var isAlertPresented: Bool = false
     
     //background #5b5557
     let lightGray = Color(hue: 0.94, saturation: 0.03, brightness: 0.35)
@@ -234,11 +235,14 @@ struct MainScreen: View {
                             .bold()
                             .foregroundColor(.white)
                         Spacer()
-                        NavigationLink(destination: AlertView()) {
-                            Image(systemName: "exclamationmark.triangle")
-                                .imageScale(.large)
-                                .foregroundColor(.white)
-                        }
+                        Image(systemName: "exclamationmark.triangle")
+                            .onTapGesture {
+                                isAlertPresented.toggle()
+                            }
+                            .imageScale(.large)
+                            .foregroundColor(settingsStore.isAlertActivated ? .red : .white)
+                            .popover(isPresented: $isAlertPresented) { AlertView()
+                            }
                         Spacer()
                         NavigationLink(destination: ChatView(chatMessage: ChatMessage())) {
                             Image(systemName: "bubble.left")

--- a/TAKTracker/Screens/SettingsView.swift
+++ b/TAKTracker/Screens/SettingsView.swift
@@ -321,7 +321,6 @@ struct MapOptions: View {
                         .foregroundColor(.secondary)
                     Spacer()
                 }
-
                 Picker(selection: $settingsStore.mapTypeDisplay, label: Text("Map Type"), content: {
                     Text("Standard").tag(MKMapType.standard.rawValue)
                     Text("Hybrid").tag(MKMapType.hybrid.rawValue)

--- a/TAKTracker/TAK/TAKManager.swift
+++ b/TAKTracker/TAK/TAKManager.swift
@@ -45,4 +45,31 @@ class TAKManager: NSObject, URLSessionDelegate, ObservableObject {
         sendToTCP(message: message)
         TAKLogger.debug("[TAKManager]: Done broadcasting")
     }
+    
+    func initiateEmergencyAlert(location: CLLocation?) {
+        let alertType = EmergencyType(rawValue: SettingsStore.global.activeAlertType)!
+        
+        let alert = cotMessage.generateEmergencyCOTXml(latitude: location?.coordinate.latitude.formatted() ?? "", longitude: location?.coordinate.longitude.formatted() ?? "", callSign: SettingsStore.global.callSign, emergencyType: alertType, isCancelled: false)
+
+        TAKLogger.debug("[TAKManager]: Getting ready to broadcast emergency alert CoT")
+        TAKLogger.debug(alert)
+        sendToUDP(message: alert)
+        sendToTCP(message: alert)
+        TAKLogger.debug("[TAKManager]: Done broadcasting emergency alert")
+    }
+    
+    func cancelEmergencyAlert(location: CLLocation?) {
+        SettingsStore.global.activeAlertType = ""
+        SettingsStore.global.isAlertActivated = false
+        
+        let alertType = EmergencyType.Cancel
+        
+        let alert = cotMessage.generateEmergencyCOTXml(latitude: location?.coordinate.latitude.formatted() ?? "", longitude: location?.coordinate.longitude.formatted() ?? "", callSign: SettingsStore.global.callSign, emergencyType: alertType, isCancelled: true)
+
+        TAKLogger.debug("[TAKManager]: Getting ready to broadcast emergency alert cancellation CoT")
+        TAKLogger.debug(alert)
+        sendToUDP(message: alert)
+        sendToTCP(message: alert)
+        TAKLogger.debug("[TAKManager]: Done broadcasting emergency alert cancellation")
+    }
 }


### PR DESCRIPTION
As per Issue #11 this PR adds in the ability to send and cancel Emergency Beacon alerts for the user

They must toggle both switches or they can't continue
<img width="366" alt="image" src="https://github.com/flighttactics/TAKTracker/assets/99811/07da4b58-6725-48fd-93ec-1504c8d34311">

They can continue once both switches are toggled
<img width="362" alt="image" src="https://github.com/flighttactics/TAKTracker/assets/99811/dc7a3aaf-ecef-4d75-a8fa-cb689dbed92d">

Closes #11 
