### PR TITLE
Use Full Screen for the Map

### DIFF
--- a/TAKTracker/Communications/TCPMessage.swift
+++ b/TAKTracker/Communications/TCPMessage.swift
@@ -59,7 +59,9 @@ class TCPMessage: NSObject, ObservableObject {
         
         guard let connection = connection else {
             TAKLogger.debug("[TCPMessage]: Connection was not viable so doing a full connect")
-            SettingsStore.global.isConnectingToServer = false
+            DispatchQueue.main.async {
+                SettingsStore.global.isConnectingToServer = false
+            }
             connect()
             return
         }

--- a/TAKTracker/Screens/MainScreen.swift
+++ b/TAKTracker/Screens/MainScreen.swift
@@ -149,7 +149,7 @@ struct MapView: UIViewRepresentable {
 
     func updateUIView(_ view: MKMapView, context: Context) {
         view.mapType = MKMapType(rawValue: UInt(mapType))!
-        view.isHidden = view.frame.height < 100
+        view.isHidden = view.frame.height < 150
     }
     
     func resetMap() {
@@ -343,19 +343,40 @@ struct MainScreen: View {
                             region: $manager.region,
                             mapType: $settingsStore.mapTypeDisplay
                         )
+                    } else {
+                        Spacer()
                     }
-                    Spacer()
-                    HStack {
-                        if(settingsStore.isConnectedToServer) {
-                            Text("Server: Connected").foregroundColor(.green)
-                        } else {
-                            Text("Server: \(settingsStore.connectionStatus)").foregroundColor(.red)
-                        }
-                    }
-                    .font(.system(size: 15))
                 }
                 .background(lightGray)
-                .padding()
+                .ignoresSafeArea(edges: .bottom)
+                .safeAreaInset(edge: .bottom, alignment: .trailing) {
+                    VStack {
+                        HStack {
+                            if(settingsStore.isConnectedToServer) {
+                                Text("Server: Connected")
+                                    .foregroundColor(.green)
+                                    .font(.system(size: 15))
+                                    .background(.black)
+                                    .padding(.all, 10)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 12)
+                                            .stroke(lineWidth: 1.0)
+                                            .fill(.black)
+                                    )
+                            } else {
+                                Text("Server: \(settingsStore.connectionStatus)")
+                                    .foregroundColor(.red)
+                                    .font(.system(size: 15))
+                                    .padding(.all, 5)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                                            .fill(Color.black)
+                                    )
+                            }
+                        }
+                    }
+                    .padding(.horizontal)
+                }
                 .onAppear {
                     broadcastLocation()
                     Timer.scheduledTimer(withTimeInterval: settingsStore.broadcastIntervalSeconds, repeats: true) { timer in

--- a/TAKTracker/Screens/TAKTrackerApp.swift
+++ b/TAKTracker/Screens/TAKTrackerApp.swift
@@ -52,6 +52,7 @@ struct TAKTrackerApp: App {
                             settingsStore.shouldTryReconnect = true
                         }
                     }
+                    .preferredColorScheme(.dark)
             }
         }
     }


### PR DESCRIPTION
This closes #34 which was a request to use the full device screen for the map. We do this by ignoring the bottom safe areas but then using the `safeAreaInset` to put the server status in a safe spot.

Before:
![Simulator Screenshot - iPhone 14 Pro - 2023-08-01 at 16 44 42](https://github.com/flighttactics/TAKTracker/assets/99811/0b3cd468-067d-4a79-a237-957f4d7a8383)

After
![Simulator Screenshot - iPhone 14 Pro - 2023-10-09 at 21 53 31](https://github.com/flighttactics/TAKTracker/assets/99811/2f8a072f-693f-4836-9e83-74e691a71344)
